### PR TITLE
Automate adding/removal of parent pointers for Features and Groups

### DIFF
--- a/src/main/java/de/vill/model/Feature.java
+++ b/src/main/java/de/vill/model/Feature.java
@@ -40,7 +40,20 @@ public class Feature {
         }else {
             this.featureName = name;
         }
-        children = new LinkedList<>();
+        children = new LinkedList<Group>() {
+        	@Override
+			public void add(int index, Group element) {
+        		super.set(index, element);
+        		element.setParentFeature(Feature.this);
+        	}
+        	
+        	@Override
+        	public Group set(int index,Group element) {
+        		element.setParentFeature(Feature.this);
+        		return super.set(index, element);
+        	}
+        	//TODO override more stuff- also test if this even works
+        };
         attributes = new HashMap<>();
     }
 

--- a/src/main/java/de/vill/model/Feature.java
+++ b/src/main/java/de/vill/model/Feature.java
@@ -4,9 +4,11 @@ import de.vill.config.Configuration;
 import de.vill.model.constraint.Constraint;
 import de.vill.util.Util;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 import static de.vill.util.Util.addNecessaryQuotes;
@@ -41,6 +43,20 @@ public class Feature {
             this.featureName = name;
         }
         children = new LinkedList<Group>() {
+        	        	
+        	/**
+			 * 
+			 */
+			private static final long serialVersionUID = 1L;
+
+			@Override
+        	public boolean add(Group e) {
+        		if(super.add(e)) {
+        			e.setParentFeature(Feature.this);
+        			return true;
+        		}
+        		return false;
+        	}
         	@Override
 			public void add(int index, Group element) {
         		super.set(index, element);
@@ -48,11 +64,115 @@ public class Feature {
         	}
         	
         	@Override
-        	public Group set(int index,Group element) {
-        		element.setParentFeature(Feature.this);
-        		return super.set(index, element);
+        	public Group remove(int index) {
+        		Group g=super.remove(index);
+        		g.setParentFeature(null);
+        		return g;
         	}
-        	//TODO override more stuff- also test if this even works
+        	
+        	@Override
+        	public boolean remove(Object o) {
+        		if(super.remove(o)) {
+        			((Group)o).setParentFeature(null);
+        			return true;
+        		}
+        		return false;
+        	}
+        	
+        	@Override
+        	public boolean addAll(int index, Collection<? extends Group> c) {
+        		if(super.addAll(index,c)) {
+        			c.forEach(e->e.setParentFeature(Feature.this));
+        			return true;
+        		}
+        		return false;
+        	}
+        	
+        	@Override
+        	public void clear() {
+        		ListIterator<Group> it= this.listIterator();
+        		while(it.hasNext()) {
+        			it.next().setParentFeature(null);
+        		}
+        		super.clear();
+        	}
+        	
+        	@Override
+        	public Group set(int index,Group element) {
+        		Group g;
+        		if((g=super.set(index, element))!=null) {
+        			g.setParentFeature(Feature.this);
+        			return g;
+        		}
+        		return null;
+        	}
+        	
+        	class GroupIterator implements ListIterator<Group>{
+        		private ListIterator<Group> itr;
+        		Group lastReturned;
+        		
+        		public GroupIterator(ListIterator<Group> itr) {
+        			this.itr=itr;
+        		}
+
+				@Override
+				public boolean hasNext() {
+					return itr.hasNext();
+				}
+
+				@Override
+				public Group next() {
+					lastReturned=itr.next();
+					return lastReturned;
+				}
+
+				@Override
+				public boolean hasPrevious() {
+					return itr.hasPrevious();
+				}
+
+				@Override
+				public Group previous() {
+					lastReturned=itr.previous();
+					return lastReturned;
+				}
+
+				@Override
+				public int nextIndex() {
+					return itr.nextIndex();
+				}
+
+				@Override
+				public int previousIndex() {
+					return itr.previousIndex();
+				}
+
+				@Override
+				public void remove() {
+					itr.remove();
+					lastReturned.setParentFeature(null);					
+				}
+
+				@Override
+				public void set(Group e) {
+					itr.set(e);
+					lastReturned.setParentFeature(null);
+					e.setParentFeature(Feature.this);
+				}
+
+				@Override
+				public void add(Group e) {
+					itr.add(e);
+					e.setParentFeature(Feature.this);
+				}
+        		
+        	}
+        	
+        	@Override
+        	public ListIterator<Group> listIterator(int index){
+        		return new GroupIterator(super.listIterator(index));
+        	};
+        	
         };
         attributes = new HashMap<>();
     }

--- a/src/main/java/de/vill/model/Group.java
+++ b/src/main/java/de/vill/model/Group.java
@@ -3,8 +3,12 @@ package de.vill.model;
 import de.vill.config.Configuration;
 import de.vill.util.Util;
 
+import java.security.cert.CollectionCertStoreParameters;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 
 /**
  * This class represents all kinds of groups (or, alternative, mandatory, optional, cardinality)
@@ -33,7 +37,137 @@ public class Group {
      */
     public Group(GroupType groupType){
         this.GROUPTYPE = groupType;
-        features = new LinkedList<>();
+        features = new LinkedList<Feature>() {
+        	/**
+			 * 
+			 */
+			private static final long serialVersionUID = 3856024708694486586L;
+
+			@Override
+        	public boolean add(Feature e) {
+        		if(super.add(e)) {
+        			e.setParentGroup(Group.this);
+        			return true;
+        		}
+        		return false;
+        	}
+			
+			@Override
+			public void add(int index, Feature element) {
+        		super.set(index, element);
+        		element.setParentGroup(Group.this);
+        	}
+        	
+        	@Override
+        	public Feature remove(int index) {
+        		Feature f=super.remove(index);
+        		f.setParentGroup(null);
+        		return f;
+        	}
+        	
+        	@Override
+        	public boolean remove(Object o) {
+        		if(super.remove(o)) {
+        			((Feature)o).setParentGroup(null);
+        			return true;
+        		}
+        		return false;
+        	}
+        	
+        	@Override
+        	public boolean addAll(int index, Collection<? extends Feature> c) {
+        		if(super.addAll(index,c)) {
+        			c.forEach(e->e.setParentGroup(Group.this));
+        			return true;
+        		}
+        		return false;
+        	}
+        	
+        	@Override
+        	public void clear() {
+        		ListIterator<Feature> it= this.listIterator();
+        		while(it.hasNext()) {
+        			it.next().setParentGroup(null);
+        		}
+        		super.clear();
+        	}
+        	
+        	@Override
+        	public Feature set(int index,Feature element) {
+        		Feature f;
+        		if((f=super.set(index, element))!=null) {
+        			f.setParentGroup(Group.this);
+        			return f;
+        		}
+        		return null;
+        	}
+        	
+        	class FeatureIterator implements ListIterator<Feature>{
+        		private ListIterator<Feature> itr;
+        		Feature lastReturned;
+        		
+        		public FeatureIterator(ListIterator<Feature> itr) {
+        			this.itr=itr;
+        		}
+
+				@Override
+				public boolean hasNext() {
+					return itr.hasNext();
+				}
+
+				@Override
+				public Feature next() {
+					lastReturned=itr.next();
+					return lastReturned;
+				}
+
+				@Override
+				public boolean hasPrevious() {
+					return itr.hasPrevious();
+				}
+
+				@Override
+				public Feature previous() {
+					lastReturned=itr.previous();
+					return lastReturned;
+				}
+
+				@Override
+				public int nextIndex() {
+					return itr.nextIndex();
+				}
+
+				@Override
+				public int previousIndex() {
+					return itr.previousIndex();
+				}
+
+				@Override
+				public void remove() {
+					itr.remove();
+					lastReturned.setParentGroup(null);
+				}
+
+				@Override
+				public void set(Feature e) {
+					itr.set(e);
+					lastReturned.setParentGroup(null);
+					e.setParentGroup(Group.this);
+				}
+
+				@Override
+				public void add(Feature e) {
+					itr.add(e);
+					e.setParentGroup(Group.this);
+				}
+        		
+        	}
+        	
+        	@Override
+        	public ListIterator<Feature> listIterator(int index){
+        		return new FeatureIterator(super.listIterator(index));
+        	};
+        };
     }
 
     /**

--- a/src/test/java/de/vill/model/FeatureTest.java
+++ b/src/test/java/de/vill/model/FeatureTest.java
@@ -1,0 +1,89 @@
+package de.vill.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.vill.model.Group.GroupType;
+
+class FeatureTest {
+	Feature feature;
+	Group orGroup;
+	List<Group> groupList;
+	
+	@BeforeEach
+	void setUp() throws Exception {
+		feature= new Feature("TheFeature");
+		orGroup= new Group(GroupType.OR);
+		feature.addChildren(orGroup);
+		groupList=new LinkedList<>();
+		groupList.add(new Group(GroupType.ALTERNATIVE));
+		groupList.add(new Group(GroupType.MANDATORY));
+		groupList.add(new Group(GroupType.OPTIONAL));
+	}
+
+	@Test
+	void testAddChildren() {
+		assertEquals(feature,orGroup.getParentFeature());
+	}
+	
+	@Test
+	void testRemoveChildren() {
+		assertEquals(feature,orGroup.getParentFeature());
+		feature.getChildren().remove(orGroup);
+		assertNull(orGroup.getParentFeature());
+		assertTrue(feature.getChildren().isEmpty());
+	}
+	
+	@Test
+	void testRemoveIf() {
+		feature.getChildren().removeIf(e->true);
+		assertNull(orGroup.getParentFeature());
+		assertTrue(feature.getChildren().isEmpty());
+	}
+	
+	@Test
+	void testAddAll() {
+		feature.getChildren().addAll(groupList);
+		assertTrue(feature.getChildren().containsAll(groupList));
+		for(Group g:feature.getChildren()) {
+			assertEquals(feature,g.getParentFeature());
+		}
+	}
+	
+	@Test
+	void testRemoveAll() {
+		feature.getChildren().removeAll(groupList);
+		assertFalse(feature.getChildren().containsAll(groupList));
+		for(Group g:groupList) {
+			assertNull(g.getParentFeature());
+		}
+	}
+	
+	@Test
+	void testRetainAll() {
+		feature.getChildren().retainAll(groupList);
+		assertNull(orGroup.getParentFeature());
+	}
+	
+	@Test
+	void testClear() {
+		feature.getChildren().clear();
+		assertNull(orGroup.getParentFeature());
+		for(Group g:groupList) {
+			assertNull(g.getParentFeature());
+		}
+	}
+	
+	@Test
+	void testSet() {
+		Group newGroup= new Group(GroupType.ALTERNATIVE);		
+		assertEquals(feature,feature.getChildren().set(0, newGroup).getParentFeature());
+	}
+
+}


### PR DESCRIPTION
This pull request streamlines the feature request from Issue #4 . Since commit [3381881353eebb40fe92f5512baa0b5b276ce341](https://github.com/Universal-Variability-Language/uvl-parser2.0/commit/3381881353eebb40fe92f5512baa0b5b276ce341) only builds the parent references when the model is created through the parser, I have modified the implementation of the Lists used to store Groups and Features respectively to automatically update parent references when they are added/removed through the List interface.
This also includes a wrapper for the given ListIterator to allow for more complex operations to still automatically update the references.

This should automate the requested behavior also in cases where the UVLModel is built manually without the use of the parse method, and doesn't impose any changes to the established API. 

I've also included a number of test cases.

Cheers!