### PR TITLE
Fixes #8: toString() now provides correct order

### DIFF
--- a/src/main/java/de/vill/model/FeatureModel.java
+++ b/src/main/java/de/vill/model/FeatureModel.java
@@ -265,7 +265,7 @@ public class FeatureModel {
      * model.
      *
      * @return a map with namespaces of featuremodel and submodels as key and uvl
-     * strings as value
+     *         strings as value
      */
     public Map<String, String> decomposedModelToString() {
         return decomposedModelToString("");
@@ -291,6 +291,12 @@ public class FeatureModel {
 
     private String toString(boolean withSubmodels, String currentAlias) {
         StringBuilder result = new StringBuilder();
+        if (namespace != null) {
+            result.append("namespace ");
+            result.append(addNecessaryQuotes(namespace));
+            result.append(Configuration.getNewlineSymbol());
+            result.append(Configuration.getNewlineSymbol());
+        }
         if (explicitLanguageLevels && usedLanguageLevels.size() != 0) {
             result.append("include");
             result.append(Configuration.getNewlineSymbol());
@@ -310,12 +316,6 @@ public class FeatureModel {
                 result.append(languageLevel.getName());
                 result.append(Configuration.getNewlineSymbol());
             }
-            result.append(Configuration.getNewlineSymbol());
-        }
-        if (namespace != null) {
-            result.append("namespace ");
-            result.append(addNecessaryQuotes(namespace));
-            result.append(Configuration.getNewlineSymbol());
             result.append(Configuration.getNewlineSymbol());
         }
         if (imports.size() > 0 && !withSubmodels) {
@@ -376,7 +376,7 @@ public class FeatureModel {
      * when adding for example constraints.
      *
      * @return a list with all {@link LiteralConstraint} objects in the constraints
-     * of this feature model.
+     *         of this feature model.
      */
     public List<LiteralConstraint> getLiteralConstraints() {
         return literalConstraints;
@@ -389,7 +389,7 @@ public class FeatureModel {
      * when adding for example constraints.
      *
      * @return a list with all {@link LiteralExpression} objects in the constraints
-     * of this feature model.
+     *         of this feature model.
      */
     public List<LiteralExpression> getLiteralExpressions() {
         return literalExpressions;
@@ -402,7 +402,7 @@ public class FeatureModel {
      * when adding for example constraints.
      *
      * @return a list with all {@link AggregateFunctionExpression} objects in the
-     * constraints of this feature model.
+     *         constraints of this feature model.
      */
     public List<AggregateFunctionExpression> getAggregateFunctionsWithRootFeature() {
         return aggregateFunctionsWithRootFeature;

--- a/src/test/java/de/vill/model/ReadWriteTest.java
+++ b/src/test/java/de/vill/model/ReadWriteTest.java
@@ -1,0 +1,31 @@
+package de.vill.model;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import de.vill.main.UVLModelFactory;
+
+public class ReadWriteTest {
+    
+    private final static String TEMP_PATH = "temp.uvl";
+    private final static String TEST_MODEL_ONE = "src/test/resources/test1.uvl";
+
+    @Test
+    void testReadWrite() throws Exception {
+        UVLModelFactory uvlModelFactory = new UVLModelFactory();
+        
+        // Read
+        String content = new String(Files.readAllBytes(Paths.get(TEST_MODEL_ONE)));
+        FeatureModel featureModel = uvlModelFactory.parse(content);
+
+        // Write
+        Files.write(Paths.get(TEMP_PATH), featureModel.toString().getBytes());
+
+        // Try reading again
+        content = new String(Files.readAllBytes(Paths.get(TEMP_PATH)));
+        uvlModelFactory.parse(content);
+        Files.delete(Paths.get(TEMP_PATH));
+    }
+}

--- a/src/test/resources/composition_root.uvl
+++ b/src/test/resources/composition_root.uvl
@@ -1,8 +1,9 @@
+namespace composition_root
+
 include
 	SAT-level
 	SAT-level.group-cardinality
 
-namespace composition_root
 
 imports
 	composition_sub1

--- a/src/test/resources/test1.uvl
+++ b/src/test/resources/test1.uvl
@@ -1,0 +1,27 @@
+namespace test1
+
+include
+    SAT-level
+
+features
+    Root
+        optional
+            opt1
+            opt2
+                alternative
+                    alt1
+                    alt2
+                    alt3
+        mandatory
+            mand1
+            mand2
+                or
+                    or1
+                    or2
+                    or3
+
+constraints
+    or1 => alt1
+    opt1 <=> or3
+    opt1 | opt2
+        


### PR DESCRIPTION
Writing and then again reading an UVL model resulted in an error as the toString() method produced a wrong order of namespace and include