### PR TITLE
Issue 23: Renamed language levels

### DIFF
--- a/src/main/antlr4/de/vill/UVL.g4
+++ b/src/main/antlr4/de/vill/UVL.g4
@@ -191,7 +191,7 @@ numericAggregateFunction
 
 reference: (id '.')* id;
 id: ID_STRICT | ID_NOT_STRICT;
-featureType: 'String' | 'Integer' | 'Boolean' | 'Real';
+featureType: 'String' | 'Integer' | BOOLEAN_KEY | 'Real';
 
 ORGROUP: 'or';
 ALTERNATIVE: 'alternative';
@@ -222,8 +222,10 @@ INTEGER: '0' | '-'?[1-9][0-9]*;
 BOOLEAN: 'true' | 'false';
 
 LANGUAGELEVEL: MAJORLEVEL ('.' (MINORLEVEL | '*'))?;
-MAJORLEVEL: 'SAT-level' | 'SMT-level' | 'TYPE-level';
-MINORLEVEL: 'group-cardinality' | 'feature-cardinality' | 'aggregate-function' | 'string-constraints' | 'numeric-constraints';
+MAJORLEVEL: BOOLEAN_KEY | 'Arithmetic' | 'Type';
+MINORLEVEL: 'group-cardinality' | 'feature-cardinality' | 'aggregate-function' | 'string-constraints';
+
+BOOLEAN_KEY : 'Boolean';
 
 COMMA: ',';
 

--- a/src/main/antlr4/de/vill/UVL.g4
+++ b/src/main/antlr4/de/vill/UVL.g4
@@ -95,7 +95,7 @@ tokens { INDENT, DEDENT }
 featureModel: namespace? NEWLINE? includes? NEWLINE? imports? NEWLINE? features? NEWLINE? constraints? EOF;
 
 includes: 'include' NEWLINE INDENT includeLine* DEDENT;
-includeLine: LANGUAGELEVEL NEWLINE;
+includeLine: languageLevel NEWLINE;
 
 namespace: 'namespace' reference;
 
@@ -193,6 +193,12 @@ reference: (id '.')* id;
 id: ID_STRICT | ID_NOT_STRICT;
 featureType: 'String' | 'Integer' | BOOLEAN_KEY | 'Real';
 
+
+
+languageLevel: majorLevel ('.' (minorLevel | '*'))?;
+majorLevel: BOOLEAN_KEY | 'Arithmetic' | 'Type';
+minorLevel: 'group-cardinality' | 'feature-cardinality' | 'aggregate-function' | 'string-constraints';
+
 ORGROUP: 'or';
 ALTERNATIVE: 'alternative';
 OPTIONAL: 'optional';
@@ -220,10 +226,6 @@ SUB: '-';
 FLOAT: '-'?[0-9]*[.][0-9]+;
 INTEGER: '0' | '-'?[1-9][0-9]*;
 BOOLEAN: 'true' | 'false';
-
-LANGUAGELEVEL: MAJORLEVEL ('.' (MINORLEVEL | '*'))?;
-MAJORLEVEL: BOOLEAN_KEY | 'Arithmetic' | 'Type';
-MINORLEVEL: 'group-cardinality' | 'feature-cardinality' | 'aggregate-function' | 'string-constraints';
 
 BOOLEAN_KEY : 'Boolean';
 

--- a/src/main/java/de/vill/conversion/ConvertAggregateFunction.java
+++ b/src/main/java/de/vill/conversion/ConvertAggregateFunction.java
@@ -18,7 +18,7 @@ public class ConvertAggregateFunction implements IConversionStrategy {
 
     @Override
     public Set<LanguageLevel> getTargetLevelsOfConversion() {
-        return new HashSet<>(Arrays.asList(LanguageLevel.SMT_LEVEL));
+        return new HashSet<>(Arrays.asList(LanguageLevel.ARITHMETIC_LEVEL));
     }
 
     @Override

--- a/src/main/java/de/vill/conversion/ConvertFeatureCardinality.java
+++ b/src/main/java/de/vill/conversion/ConvertFeatureCardinality.java
@@ -16,7 +16,7 @@ public class ConvertFeatureCardinality implements IConversionStrategy {
 
     @Override
     public Set<LanguageLevel> getTargetLevelsOfConversion() {
-        return new HashSet<>(Arrays.asList(LanguageLevel.SMT_LEVEL));
+        return new HashSet<>(Arrays.asList(LanguageLevel.ARITHMETIC_LEVEL));
     }
 
     @Override

--- a/src/main/java/de/vill/conversion/ConvertGroupCardinality.java
+++ b/src/main/java/de/vill/conversion/ConvertGroupCardinality.java
@@ -19,7 +19,7 @@ public class ConvertGroupCardinality implements IConversionStrategy {
 
     @Override
     public Set<LanguageLevel> getTargetLevelsOfConversion() {
-        return new HashSet<>(Arrays.asList(LanguageLevel.SAT_LEVEL));
+        return new HashSet<>(Arrays.asList(LanguageLevel.BOOLEAN_LEVEL));
     }
 
     @Override

--- a/src/main/java/de/vill/conversion/ConvertSMTLevel.java
+++ b/src/main/java/de/vill/conversion/ConvertSMTLevel.java
@@ -11,12 +11,12 @@ import java.util.*;
 public class ConvertSMTLevel implements IConversionStrategy {
     @Override
     public Set<LanguageLevel> getLevelsToBeRemoved() {
-        return new HashSet<>(Arrays.asList(LanguageLevel.SMT_LEVEL));
+        return new HashSet<>(Arrays.asList(LanguageLevel.ARITHMETIC_LEVEL));
     }
 
     @Override
     public Set<LanguageLevel> getTargetLevelsOfConversion() {
-        return new HashSet<>(Arrays.asList(LanguageLevel.SAT_LEVEL));
+        return new HashSet<>(Arrays.asList(LanguageLevel.BOOLEAN_LEVEL));
     }
 
     @Override

--- a/src/main/java/de/vill/conversion/ConvertTypeLevel.java
+++ b/src/main/java/de/vill/conversion/ConvertTypeLevel.java
@@ -25,7 +25,7 @@ public class ConvertTypeLevel implements IConversionStrategy {
 
     @Override
     public Set<LanguageLevel> getTargetLevelsOfConversion() {
-        return new HashSet<>(Collections.singletonList(LanguageLevel.SMT_LEVEL));
+        return new HashSet<>(Collections.singletonList(LanguageLevel.ARITHMETIC_LEVEL));
     }
 
     @Override

--- a/src/main/java/de/vill/conversion/DropSMTLevel.java
+++ b/src/main/java/de/vill/conversion/DropSMTLevel.java
@@ -11,7 +11,7 @@ import java.util.Set;
 public class DropSMTLevel implements IConversionStrategy {
     @Override
     public Set<LanguageLevel> getLevelsToBeRemoved() {
-        return new HashSet<>(Arrays.asList(LanguageLevel.SMT_LEVEL));
+        return new HashSet<>(Arrays.asList(LanguageLevel.ARITHMETIC_LEVEL));
     }
 
     @Override

--- a/src/main/java/de/vill/main/UVLListener.java
+++ b/src/main/java/de/vill/main/UVLListener.java
@@ -52,7 +52,7 @@ import org.antlr.v4.runtime.Token;
 
 public class UVLListener extends UVLBaseListener {
     private FeatureModel featureModel = new FeatureModel();
-    private Set<LanguageLevel> importedLanguageLevels = new HashSet<>(Arrays.asList(LanguageLevel.SAT_LEVEL));
+    private Set<LanguageLevel> importedLanguageLevels = new HashSet<>(Arrays.asList(LanguageLevel.BOOLEAN_LEVEL));
     private Stack<Feature> featureStack = new Stack<>();
     private Stack<Group> groupStack = new Stack<>();
 
@@ -294,7 +294,7 @@ public class UVLListener extends UVLBaseListener {
         feature.setLowerBound(lowerBound);
         feature.setUpperBound(upperBound);
 
-        featureModel.getUsedLanguageLevels().add(LanguageLevel.SMT_LEVEL);
+        featureModel.getUsedLanguageLevels().add(LanguageLevel.ARITHMETIC_LEVEL);
         featureModel.getUsedLanguageLevels().add(LanguageLevel.FEATURE_CARDINALITY);
     }
 
@@ -542,7 +542,7 @@ public class UVLListener extends UVLBaseListener {
                 featureModel.getUsedLanguageLevels().add(LanguageLevel.TYPE_LEVEL);
                 featureModel.getUsedLanguageLevels().add(LanguageLevel.STRING_CONSTRAINTS);
             } else {
-                featureModel.getUsedLanguageLevels().add(LanguageLevel.SMT_LEVEL);
+                featureModel.getUsedLanguageLevels().add(LanguageLevel.ARITHMETIC_LEVEL);
             }
         }
         expressionStack.push(expression);
@@ -566,7 +566,7 @@ public class UVLListener extends UVLBaseListener {
         LiteralExpression expression = new LiteralExpression(reference);
         String[] splitReference = reference.split("\\.");
         if (splitReference.length > 1) {
-            featureModel.getUsedLanguageLevels().add(LanguageLevel.SMT_LEVEL);
+            featureModel.getUsedLanguageLevels().add(LanguageLevel.ARITHMETIC_LEVEL);
         }
         expressionStack.push(expression);
         featureModel.getLiteralExpressions().add(expression);
@@ -621,7 +621,7 @@ public class UVLListener extends UVLBaseListener {
 
     @Override
     public void exitSumAggregateFunction(UVLParser.SumAggregateFunctionContext ctx) {
-        featureModel.getUsedLanguageLevels().add(LanguageLevel.SMT_LEVEL);
+        featureModel.getUsedLanguageLevels().add(LanguageLevel.ARITHMETIC_LEVEL);
         featureModel.getUsedLanguageLevels().add(LanguageLevel.AGGREGATE_FUNCTION);
         AggregateFunctionExpression expression;
         if (ctx.reference().size() > 1) {
@@ -638,7 +638,7 @@ public class UVLListener extends UVLBaseListener {
 
     @Override
     public void exitAvgAggregateFunction(UVLParser.AvgAggregateFunctionContext ctx) {
-        featureModel.getUsedLanguageLevels().add(LanguageLevel.SMT_LEVEL);
+        featureModel.getUsedLanguageLevels().add(LanguageLevel.ARITHMETIC_LEVEL);
         featureModel.getUsedLanguageLevels().add(LanguageLevel.AGGREGATE_FUNCTION);
         AggregateFunctionExpression expression;
         if (ctx.reference().size() > 1) {

--- a/src/main/java/de/vill/main/UVLListener.java
+++ b/src/main/java/de/vill/main/UVLListener.java
@@ -73,7 +73,7 @@ public class UVLListener extends UVLBaseListener {
 
     @Override
     public void exitIncludeLine(UVLParser.IncludeLineContext ctx) {
-        String[] levels = ctx.LANGUAGELEVEL().getText().split("\\.");
+        String[] levels = ctx.languageLevel().getText().split("\\.");
         if (levels.length == 1) {
             LanguageLevel majorLevel = LanguageLevel.getLevelByName(levels[0]);
             importedLanguageLevels.add(majorLevel);
@@ -94,7 +94,7 @@ public class UVLListener extends UVLBaseListener {
                 importedLanguageLevels.add(minorLevel);
             }
         } else {
-            errorList.add(new ParseError("Invalid import Statement: " + ctx.LANGUAGELEVEL().getText()));
+            errorList.add(new ParseError("Invalid import Statement: " + ctx.languageLevel().getText()));
             //throw new ParseError("Invalid import Statement: " + ctx.LANGUAGELEVEL().getText());
         }
     }

--- a/src/main/java/de/vill/main/UVLModelFactory.java
+++ b/src/main/java/de/vill/main/UVLModelFactory.java
@@ -64,7 +64,7 @@ public class UVLModelFactory {
         this.conversionStrategiesDrop.put(LanguageLevel.GROUP_CARDINALITY, DropGroupCardinality.class);
         this.conversionStrategiesDrop.put(LanguageLevel.FEATURE_CARDINALITY, DropFeatureCardinality.class);
         this.conversionStrategiesDrop.put(LanguageLevel.AGGREGATE_FUNCTION, DropAggregateFunction.class);
-        this.conversionStrategiesDrop.put(LanguageLevel.SMT_LEVEL, DropSMTLevel.class);
+        this.conversionStrategiesDrop.put(LanguageLevel.ARITHMETIC_LEVEL, DropSMTLevel.class);
         this.conversionStrategiesDrop.put(LanguageLevel.TYPE_LEVEL, DropTypeLevel.class);
         this.conversionStrategiesDrop.put(LanguageLevel.STRING_CONSTRAINTS, DropStringConstraints.class);
         this.conversionStrategiesDrop.put(LanguageLevel.NUMERIC_CONSTRAINTS, DropNumericConstraints.class);
@@ -72,7 +72,7 @@ public class UVLModelFactory {
         this.conversionStrategiesConvert.put(LanguageLevel.GROUP_CARDINALITY, ConvertGroupCardinality.class);
         this.conversionStrategiesConvert.put(LanguageLevel.FEATURE_CARDINALITY, ConvertFeatureCardinality.class);
         this.conversionStrategiesConvert.put(LanguageLevel.AGGREGATE_FUNCTION, ConvertAggregateFunction.class);
-        this.conversionStrategiesConvert.put(LanguageLevel.SMT_LEVEL, ConvertSMTLevel.class);
+        this.conversionStrategiesConvert.put(LanguageLevel.ARITHMETIC_LEVEL, ConvertSMTLevel.class);
         this.conversionStrategiesConvert.put(LanguageLevel.TYPE_LEVEL, ConvertTypeLevel.class);
         this.conversionStrategiesConvert.put(LanguageLevel.STRING_CONSTRAINTS, ConvertStringConstraints.class);
         this.conversionStrategiesConvert.put(LanguageLevel.NUMERIC_CONSTRAINTS, ConvertNumericConstraints.class);
@@ -268,7 +268,7 @@ public class UVLModelFactory {
 
 
     private LanguageLevel getMaxLanguageLevel(Set<LanguageLevel> languageLevels) {
-        LanguageLevel max = LanguageLevel.SAT_LEVEL;
+        LanguageLevel max = LanguageLevel.BOOLEAN_LEVEL;
         for (LanguageLevel languageLevel : languageLevels) {
             if (languageLevel.getValue() > max.getValue()) {
                 max = languageLevel;
@@ -312,7 +312,7 @@ public class UVLModelFactory {
             }
         }
         //SAT-level can not be removed
-        completeOrderedLevelsToRemove.remove(LanguageLevel.SAT_LEVEL);
+        completeOrderedLevelsToRemove.remove(LanguageLevel.BOOLEAN_LEVEL);
 
         return completeOrderedLevelsToRemove;
     }

--- a/src/main/java/de/vill/model/FeatureModel.java
+++ b/src/main/java/de/vill/model/FeatureModel.java
@@ -18,7 +18,7 @@ import static de.vill.util.Util.addNecessaryQuotes;
 public class FeatureModel {
     private final Set<LanguageLevel> usedLanguageLevels = new HashSet<LanguageLevel>() {
         {
-            add(LanguageLevel.SAT_LEVEL);
+            add(LanguageLevel.BOOLEAN_LEVEL);
         }
     };
     private String namespace;

--- a/src/main/java/de/vill/model/LanguageLevel.java
+++ b/src/main/java/de/vill/model/LanguageLevel.java
@@ -4,14 +4,16 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
+import de.vill.util.Constants;
+
 /**
  * An enum that represents all possible language levels this UVL library supports.
  */
 public enum LanguageLevel {
     // MAJOR LEVELS (logic: val % 2 != 0)
-    SAT_LEVEL(1, "SAT-level"),
-    SMT_LEVEL(3, "SMT-level"),
-    TYPE_LEVEL(5, "TYPE-level"),
+    BOOLEAN_LEVEL(1, Constants.BOOLEAN_LEVEL),
+    ARITHMETIC_LEVEL(3, Constants.ARITHMETIC_LEVEL),
+    TYPE_LEVEL(5, Constants.TYPE_LEVEL),
 
     // MINOR LEVELS (logic: val % 2 == 0)
     GROUP_CARDINALITY(2, "group-cardinality"),

--- a/src/main/java/de/vill/util/Constants.java
+++ b/src/main/java/de/vill/util/Constants.java
@@ -11,4 +11,11 @@ public class Constants {
     // Default attribtues
     public static final String TYPE_LEVEL_VALUE = "type_level_value";
     public static final String TYPE_LEVEL_LENGTH = "type_level_value_length";
+
+
+    // Language Levels
+    public static final String BOOLEAN_LEVEL = "Boolean";
+    public static final String ARITHMETIC_LEVEL = "Arithmetic";
+    public static final String TYPE_LEVEL = "Type";
+
 }


### PR DESCRIPTION
The three major language levels have been renamed:

* SAT-level -> Boolean
* SMT-level -> Arithmetic
* TYPE-level -> Type