### PR TITLE
fix: correct constraint usage in parser and lexer definitions

### DIFF
--- a/uvl/UVLLexer.g4
+++ b/uvl/UVLLexer.g4
@@ -8,6 +8,7 @@ FEATURES_KEY: 'features';
 IMPORTS_KEY: 'imports';
 NAMESPACE_KEY: 'namespace';
 AS_KEY: 'as';
+CONSTRAINT_KEY: 'constraint';
 CONSTRAINTS_KEY: 'constraints';
 CARDINALITY_KEY: 'cardinality';
 STRING_KEY: 'String';
@@ -60,17 +61,17 @@ CLOSE_BRACE: '}';
 OPEN_COMMENT: '/*';
 CLOSE_COMMENT: '*/';
 
-FLOAT: '-'? [0-9]* [.][0-9]+;
-INTEGER: '0' | '-'? [1-9][0-9]*;
+FLOAT: '-'?[0-9]*[.][0-9]+;
+INTEGER: '0' | '-'?[1-9][0-9]*;
 BOOLEAN: 'true' | 'false';
 
 COMMA: ',';
 DOT: '.';
 
-ID_NOT_STRICT: '"' ~[\r\n".]+ '"';
+ID_NOT_STRICT: '"'~[\r\n".]+'"';
 ID_STRICT: [a-zA-Z]([a-zA-Z0-9_#§%?\\'äüöß;])*;
 
-STRING: '\'' ~[\r\n']+ '\'';
+STRING: '\''~[\r\n'.]+'\'';
 
 SKIP_: ( SPACES | COMMENT) -> skip;
 

--- a/uvl/UVLParser.g4
+++ b/uvl/UVLParser.g4
@@ -44,7 +44,7 @@ value: BOOLEAN | FLOAT | INTEGER | STRING | attributes | vector;
 vector: OPEN_BRACK (value (COMMA value)*)? CLOSE_BRACK;
 
 constraintAttribute:
-	CONSTRAINTS_KEY constraint			# SingleConstraintAttribute
+	CONSTRAINT_KEY constraint			# SingleConstraintAttribute
 	| CONSTRAINTS_KEY constraintList	# ListConstraintAttribute;
 constraintList:
 	OPEN_BRACK (constraint (COMMA constraint)*)? CLOSE_BRACK;


### PR DESCRIPTION
After the refactoring changes made in https://github.com/Universal-Variability-Language/uvl-parser/pull/60 , introduced some regex  errors, containing blanks spaces in the float number definitions and other minor errors
